### PR TITLE
Feat/diary date field

### DIFF
--- a/src/main/java/graduation/spendiary/controller/DiaryController.java
+++ b/src/main/java/graduation/spendiary/controller/DiaryController.java
@@ -3,12 +3,14 @@ package graduation.spendiary.controller;
 import graduation.spendiary.domain.diary.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
+import java.time.LocalDate;
 import java.util.List;
 
 @RestController
@@ -33,11 +35,19 @@ public class DiaryController {
         return diaryDto;
     }
 
-    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public DiaryDto addDiary(@AuthenticationPrincipal String userId, @ModelAttribute DiarySaveVo vo)
-            throws IOException
-    {
-        return diaryService.save(vo, userId);
+//    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+//    public DiaryDto addDiary(@AuthenticationPrincipal String userId, @ModelAttribute DiarySaveVo vo)
+//            throws IOException
+//    {
+//        return diaryService.save(vo, userId);
+//    }
+
+    @PostMapping
+    public Long saveEmptyDiary(
+            @AuthenticationPrincipal String userId,
+            @RequestParam("date") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate diaryDate
+    ) {
+        return diaryService.saveEmptyDiary(diaryDate, userId);
     }
 
     @GetMapping("/last-week")

--- a/src/main/java/graduation/spendiary/controller/DiaryController.java
+++ b/src/main/java/graduation/spendiary/controller/DiaryController.java
@@ -1,6 +1,7 @@
 package graduation.spendiary.controller;
 
 import graduation.spendiary.domain.diary.*;
+import graduation.spendiary.exception.DiaryDuplicatedException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -46,8 +47,9 @@ public class DiaryController {
     public Long saveEmptyDiary(
             @AuthenticationPrincipal String userId,
             @RequestParam("date") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate diaryDate
-    ) {
-        return diaryService.saveEmptyDiary(diaryDate, userId);
+    ) throws DiaryDuplicatedException
+    {
+        return diaryService.saveEmptyDiary(userId, diaryDate);
     }
 
     @GetMapping("/last-week")

--- a/src/main/java/graduation/spendiary/domain/diary/Diary.java
+++ b/src/main/java/graduation/spendiary/domain/diary/Diary.java
@@ -38,6 +38,9 @@ public class Diary {
     @Field("diary_create")
     private LocalDate created;
 
+    @Field("diary_date")
+    private LocalDate date;
+
     @Field("diary_image")
     private List<String> images;
 

--- a/src/main/java/graduation/spendiary/domain/diary/DiaryRepository.java
+++ b/src/main/java/graduation/spendiary/domain/diary/DiaryRepository.java
@@ -9,6 +9,9 @@ import java.util.List;
 
 @Repository
 public interface DiaryRepository extends MongoRepository<Diary, Long> {
+    @Query(value = "{'user_id': ?0, 'diary_date': ?1}")
+    List<Diary> findByUserAndDate(String userId, LocalDate date);
+
     @Query(value = "{'user_id': ?0, 'diary_create': {$gte: ?1, $lte: ?2}}")
     List<Diary> findByUserAndCreatedBetween(String userId, LocalDate start, LocalDate end);
 }

--- a/src/main/java/graduation/spendiary/domain/diary/DiaryService.java
+++ b/src/main/java/graduation/spendiary/domain/diary/DiaryService.java
@@ -67,9 +67,6 @@ public class DiaryService {
     public DiaryDto save(DiarySaveVo vo, String userId)
         throws IOException
     {
-        System.out.println("widget: ---");
-        System.out.println(vo.getWidget());
-
         // 이미지 파일 업로드
         List<String> fileNames = uploadImages(vo.getImages());
 
@@ -93,6 +90,21 @@ public class DiaryService {
         // 다이어리 저장
         repo.save(diary);
         return this.getDto(diary);
+    }
+
+    public Long saveEmptyDiary(LocalDate diarydate, String userId) {
+        Diary diary = Diary.builder()
+                .title("")
+                .content("")
+                .user(userId)
+                .images(Collections.emptyList())
+                .date(diarydate)
+                .weather("")
+                .build();
+        diary.setId(SequenceGeneratorService.generateSequence(Diary.SEQUENCE_NAME));
+
+        Diary savedDiary = repo.save(diary);
+        return savedDiary.getId();
     }
 
     public List<DiaryDto> getDtoByCreatedRange(String userId, LocalDate start, LocalDate end) {

--- a/src/main/java/graduation/spendiary/domain/diary/DiaryService.java
+++ b/src/main/java/graduation/spendiary/domain/diary/DiaryService.java
@@ -4,6 +4,7 @@ import graduation.spendiary.domain.DatabaseSequence.SequenceGeneratorService;
 import graduation.spendiary.domain.cdn.CloudinaryService;
 import graduation.spendiary.domain.spendingWidget.SpendingWidgetDto;
 import graduation.spendiary.domain.spendingWidget.SpendingWidgetService;
+import graduation.spendiary.exception.DiaryDuplicatedException;
 import graduation.spendiary.exception.DiaryUneditableException;
 import graduation.spendiary.exception.NoSuchContentException;
 import graduation.spendiary.util.file.TemporalFileUtil;
@@ -92,7 +93,19 @@ public class DiaryService {
         return this.getDto(diary);
     }
 
-    public Long saveEmptyDiary(LocalDate diaryDate, String userId) {
+    /**
+     * 주어진 날짜에 해당되는 빈 다이어리를 작성합니다.
+     * @param diaryDate 다이어리의 날짜
+     * @param userId 다이어리 작성자
+     * @return 빈 다이어리
+     * @throws DiaryDuplicatedException 해당 날짜에 이미 다이어리가 있음
+     */
+    public Long saveEmptyDiary(String userId, LocalDate diaryDate)
+        throws DiaryDuplicatedException
+    {
+        if (!repo.findByUserAndDate(userId, diaryDate).isEmpty())
+            throw new DiaryDuplicatedException();
+
         Diary diary = Diary.builder()
                 .title("")
                 .content("")

--- a/src/main/java/graduation/spendiary/domain/diary/DiaryService.java
+++ b/src/main/java/graduation/spendiary/domain/diary/DiaryService.java
@@ -92,13 +92,13 @@ public class DiaryService {
         return this.getDto(diary);
     }
 
-    public Long saveEmptyDiary(LocalDate diarydate, String userId) {
+    public Long saveEmptyDiary(LocalDate diaryDate, String userId) {
         Diary diary = Diary.builder()
                 .title("")
                 .content("")
                 .user(userId)
                 .images(Collections.emptyList())
-                .date(diarydate)
+                .date(diaryDate)
                 .weather("")
                 .build();
         diary.setId(SequenceGeneratorService.generateSequence(Diary.SEQUENCE_NAME));

--- a/src/main/java/graduation/spendiary/exception/DiaryDuplicatedException.java
+++ b/src/main/java/graduation/spendiary/exception/DiaryDuplicatedException.java
@@ -1,0 +1,8 @@
+package graduation.spendiary.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(code = HttpStatus.FORBIDDEN, reason = "날짜가 중복되는 다이어리를 생성할 수 없음")
+public class DiaryDuplicatedException extends RuntimeException{
+}


### PR DESCRIPTION
- API 추가: `POST /api/diary?date=yyyy-MM-dd` - 주어진 날짜에 해당하는 빈 다이어리를 생성
- 기존 `POST /api/diary` API 삭제됨
- 생성자 및 다이어리 날짜가 같으면 생성할 수 없음 (403 Forbidden)